### PR TITLE
fix empty reply when an empty response is received

### DIFF
--- a/main.go
+++ b/main.go
@@ -379,6 +379,9 @@ func generateAndPostAltText(c *mastodon.Client, status *mastodon.Status, replyTo
 			if err != nil {
 				log.Printf("Error generating alt-text: %v", err)
 				altText = getLocalizedString(replyPost.Language, "altTextError", "response")
+			} else if altText == "" {
+				log.Printf("Error generating alt-text: Empty response")
+				altText = getLocalizedString(replyPost.Language, "altTextError", "response")
 			}
 
 			response = fmt.Sprintf("@%s %s", replyPost.Account.Acct, altText)


### PR DESCRIPTION
Sometimes, for reasons I have not investigated (but that I suspect may be related with the language of the post), the backend returns nothing as alt text, and the bot end up sending an empty reply as a result. This just changes that so the bot at least reply with the usual error message.

Example of such a case: https://masto.es/@altbot@fuzzies.wtf/113378915962622381