### PR TITLE
Delete AltBot's Reply if Post is Deleted Within 1 Hour

### DIFF
--- a/main.go
+++ b/main.go
@@ -29,7 +29,7 @@ import (
 )
 
 // Version of the bot
-const Version = "1.2.0"
+const Version = "1.2.1"
 
 // AsciiArt is the ASCII art for the bot
 const AsciiArt = `    _   _ _   ___     _   


### PR DESCRIPTION
### Summary

This update introduces a feature that allows AltBot to automatically delete its own replies if the original post is deleted within 1 hour of posting. This serves as a safety measure to ensure that any sensitive information inadvertently disclosed in a post is not retained by the bot.

### Details

- **Purpose**: Enhance privacy by ensuring AltBot does not retain replies to posts that have been removed by their owners shortly after posting.
- **Scope**: This feature is specifically designed to address privacy concerns and is not intended for arbitrary deletion of AltBot's replies. The presence of a reply serves as an indicator that AltBot was used to generate alt-text using AI.

### Implementation

- Utilizes an in-memory map to track the relationship between original posts and AltBot's replies for up to 1 hour.
- Periodically cleans up the map to remove entries older than 1 hour.
- Listens for delete events and removes corresponding replies if the original post is deleted within the specified timeframe.