### PR TITLE
Avoid mentioning other users

### DIFF
--- a/main.go
+++ b/main.go
@@ -1069,6 +1069,9 @@ func postProcessAltText(altText string) string {
 	// Use the regex to replace matches with an empty string
 	altText = re.ReplaceAllString(altText, "")
 
+	// Remove any mentions
+	altText = strings.ReplaceAll(altText, "@", "[@]")
+
 	// Remove any leading or trailing whitespace
 	altText = strings.TrimSpace(altText)
 


### PR DESCRIPTION
Due to the nature of LLMs, the bot can end up randomly mentioning users (even users who have nothing to do with the described image). Thus, it is a good idea to remove any mentions in the post processing.

This change was motivated by https://masto.es/@TeLoDescribot/113813791883900261