### PR TITLE
User id hashes for privacy

### DIFF
--- a/main.go
+++ b/main.go
@@ -764,7 +764,7 @@ func generateAndPostAltText(c *mastodon.Client, status *mastodon.Status, replyTo
 		}
 
 		if config.AltTextReminders.Enabled {
-			queuePostForAltTextCheck(status, replyPost.Account.Acct)
+			queuePostForAltTextCheck(status, string(replyPost.Account.ID))
 		}
 
 		// Track the reply with a timestamp

--- a/main.go
+++ b/main.go
@@ -40,7 +40,7 @@ import (
 
 // Version of the bot
 
-const Version = "1.4.2"
+const Version = "1.4.3"
 
 // AsciiArt is the ASCII art for the bot
 const AsciiArt = `    _   _ _   ___     _   

--- a/main.go
+++ b/main.go
@@ -290,7 +290,6 @@ func main() {
 	// Start metrics manager
 	metricsManager = NewMetricsManager(config.Metrics.Enabled, "metrics.json", 10*time.Second)
 	defer metricsManager.stop()
-	metricsManager.loadFromFile()
 
 	fmt.Printf("%s Metrics Collection: %v\n", getStatusSymbol(config.Metrics.Enabled), config.Metrics.Enabled)
 

--- a/metrics.go
+++ b/metrics.go
@@ -205,30 +205,6 @@ func (mm *MetricsManager) saveToFile(lock bool) {
 
 }
 
-func (mm *MetricsManager) loadFromFile() {
-	mm.fileMutex.Lock()
-	defer mm.fileMutex.Unlock()
-
-	// Check if file exists
-	if _, err := os.Stat(mm.filePath); os.IsNotExist(err) {
-		return
-	}
-
-	file, err := os.ReadFile(mm.filePath)
-	if err != nil {
-		log.Printf("Error reading metrics file: %v", err)
-		return
-	}
-
-	var existingLogs []MetricEvent
-	if err := json.Unmarshal(file, &existingLogs); err != nil {
-		log.Printf("Error parsing metrics file: %v", err)
-		return
-	}
-
-	mm.logs = existingLogs
-}
-
 func (mm *MetricsManager) run() {
 	defer mm.wg.Done()
 	for {


### PR DESCRIPTION
This pull request includes several changes to improve the metrics management system and update the alt text reminder functionality. The most important changes include adding user ID hashing, modifying the metrics manager to handle existing data, and updating the alt text check queue to use a different identifier.

### Metrics Management Improvements:
* [`metrics.go`](diffhunk://#diff-368a9e52513f8700cc50c424de862c537fc5c1a492c4598b97b960f46fc1c877L14-R16): Added SHA-256 hashing for user IDs to enhance privacy. This includes a new `hashUserID` function and modifications to the `MetricEvent` struct to store hashed user IDs. [[1]](diffhunk://#diff-368a9e52513f8700cc50c424de862c537fc5c1a492c4598b97b960f46fc1c877L14-R16) [[2]](diffhunk://#diff-368a9e52513f8700cc50c424de862c537fc5c1a492c4598b97b960f46fc1c877R32-R38) [[3]](diffhunk://#diff-368a9e52513f8700cc50c424de862c537fc5c1a492c4598b97b960f46fc1c877L70-R110)
* [`metrics.go`](diffhunk://#diff-368a9e52513f8700cc50c424de862c537fc5c1a492c4598b97b960f46fc1c877R50-R98): Implemented the `loadAndHashExistingData` function to load existing data and ensure all user IDs are hashed. This function is called during the initialization of the `MetricsManager`.
* [`metrics.go`](diffhunk://#diff-368a9e52513f8700cc50c424de862c537fc5c1a492c4598b97b960f46fc1c877L136-L154): Modified the `saveToFile` method to include an optional locking mechanism to ensure thread safety.
* [`metrics.go`](diffhunk://#diff-368a9e52513f8700cc50c424de862c537fc5c1a492c4598b97b960f46fc1c877R232-R245): Moved the `run` method to the end of the file and reintroduced it with necessary changes to call `saveToFile` with locking.

### Alt Text Reminder Update:
* [`main.go`](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L767-R766): Changed the `queuePostForAltTextCheck` function to use `replyPost.Account.ID` instead of `replyPost.Account.Acct` for queuing alt text checks.