### PR TITLE
translation feature for way better multilingual support on local LLMs

### DIFF
--- a/example.config.toml
+++ b/example.config.toml
@@ -12,6 +12,7 @@ username = "your_bot_username"                   # Your Mastodon bot's username
 [llm]
 provider = "gemini"         # can be "gemini", "ollama", or "transformers"
 ollama_model = "llava-phi3"
+use_translation_layer = true # Enable translation layer for local LLMs
 prompt_additional_instructions = "" # Additional instructions to be added to the prompt (Note: The same instructions will be added to every language)
 prompt_override = "" # WARNING: This will override the prompt making the bot only generate alt-text in one language
 

--- a/example.config.toml
+++ b/example.config.toml
@@ -12,6 +12,7 @@ username = "your_bot_username"                   # Your Mastodon bot's username
 [llm]
 provider = "gemini"         # can be "gemini", "ollama", or "transformers"
 ollama_model = "llava-phi3"
+prompt_additional_instructions = "" # Additional instructions to be added to the prompt (Note: The same instructions will be added to every language)
 prompt_override = "" # WARNING: This will override the prompt making the bot only generate alt-text in one language
 
 [transformers]

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	golang.org/x/oauth2 v0.23.0 // indirect
 	golang.org/x/sync v0.8.0 // indirect
 	golang.org/x/sys v0.25.0 // indirect
-	golang.org/x/text v0.18.0 // direct
+	golang.org/x/text v0.18.0 // indirect
 	golang.org/x/time v0.6.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240725223205-93522f1f2a9f // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240903143218-8af14fe29dc1 // indirect

--- a/locales.go
+++ b/locales.go
@@ -14,6 +14,7 @@ type Localization struct {
 var localizations map[string]Localization
 
 var PromptOverrideState bool
+var PromptAdditionState bool
 
 func loadLocalizations() error {
 	data, err := os.ReadFile("localizations.json")
@@ -37,12 +38,19 @@ func getLocalizedString(lang, key string, category string) string {
 
 	switch category {
 	case "prompt":
+		var prompt string
 		if PromptOverrideState {
-			return config.LLM.PromptOverride
+			prompt = config.LLM.PromptOverride
 		}
 		if value, ok := localization.Prompts[key]; ok {
-			return value
+			prompt = value
 		}
+
+		if PromptAdditionState {
+			prompt += " " + config.LLM.PromptAddition
+		}
+
+		return prompt
 	case "response":
 		if value, ok := localization.Responses[key]; ok {
 			return value

--- a/main.go
+++ b/main.go
@@ -54,10 +54,11 @@ type Config struct {
 		Username       string `toml:"username"`
 	} `toml:"server"`
 	LLM struct {
-		Provider       string `toml:"provider"`
-		OllamaModel    string `toml:"ollama_model"`
-		PromptAddition string `toml:"prompt_additional_instructions"`
-		PromptOverride string `toml:"prompt_override"`
+		Provider            string `toml:"provider"`
+		OllamaModel         string `toml:"ollama_model"`
+		UseTranslationLayer bool   `toml:"use_translation_layer"`
+		PromptAddition      string `toml:"prompt_additional_instructions"`
+		PromptOverride      string `toml:"prompt_override"`
 	} `toml:"llm"`
 	TransformersServerArgs struct {
 		Port       int     `toml:"port"`
@@ -916,7 +917,7 @@ func generateImageAltText(imageURL string, lang string) (string, error) {
 
 	fmt.Println("Processing image: " + imageURL)
 
-	altText, err := llmProvider.GenerateAltText(prompt, downscaledImg, format)
+	altText, err := llmProvider.GenerateAltText(prompt, downscaledImg, format, lang)
 	if err != nil {
 		return "", err
 	}

--- a/main.go
+++ b/main.go
@@ -37,7 +37,7 @@ import (
 )
 
 // Version of the bot
-const Version = "1.5"
+const Version = "1.5.1"
 
 // AsciiArt is the ASCII art for the bot
 const AsciiArt = `    _   _ _   ___     _   
@@ -56,6 +56,7 @@ type Config struct {
 	LLM struct {
 		Provider       string `toml:"provider"`
 		OllamaModel    string `toml:"ollama_model"`
+		PromptAddition string `toml:"prompt_additional_instructions"`
 		PromptOverride string `toml:"prompt_override"`
 	} `toml:"llm"`
 	TransformersServerArgs struct {
@@ -276,9 +277,12 @@ func main() {
 	}
 
 	PromptOverrideState = config.LLM.PromptOverride != ""
+	PromptAdditionState = config.LLM.PromptAddition != ""
 
 	if PromptOverrideState {
 		fmt.Printf("%s Prompt Override: Set to \"%.30s...\"\n", getStatusSymbol(true), config.LLM.PromptOverride)
+	} else if PromptAdditionState {
+		fmt.Printf("%s Prompt Additional Instructions: Set to \"%.30s...\"\n", getStatusSymbol(true), config.LLM.PromptAddition)
 	} else {
 		fmt.Printf("%s Default Prompts: %s\n", getStatusSymbol(true), "Loaded")
 	}

--- a/setup.go
+++ b/setup.go
@@ -11,6 +11,7 @@ import (
 )
 
 // RunSetupWizard guides the user through setup and writes config to a file
+// RunSetupWizard guides the user through setup and writes config to a file
 func runSetupWizard(filePath string) {
 	fmt.Println(Cyan + "Welcome to the AltBot Setup Wizard!" + Reset)
 
@@ -25,6 +26,40 @@ func runSetupWizard(filePath string) {
 	config.Server.Username = promptString(Yellow+"Bot Username:"+Reset, config.Server.Username)
 
 	config.RateLimit.AdminContactHandle = promptString(Red+"Admin Contact Handle:"+Reset, config.RateLimit.AdminContactHandle)
+
+	// LLM provider selection
+	providerOptions := []string{"gemini", "ollama", "transformers"}
+	fmt.Println(Blue + "Select LLM Provider:" + Reset)
+	for i, option := range providerOptions {
+		fmt.Printf("%d. %s\n", i+1, option)
+	}
+
+	var providerChoice int
+	for {
+		fmt.Print(Blue + "Enter choice (1-3): " + Reset)
+		fmt.Scanln(&providerChoice)
+		if providerChoice >= 1 && providerChoice <= len(providerOptions) {
+			break
+		}
+		fmt.Println(Red + "Invalid choice. Please try again." + Reset)
+	}
+	config.LLM.Provider = providerOptions[providerChoice-1]
+
+	// Add translation layer option for local LLMs
+	if config.LLM.Provider == "ollama" || config.LLM.Provider == "transformers" {
+		fmt.Println(Yellow + "\nLocal LLMs often perform better at generating alt-text in English." + Reset)
+		fmt.Println("The translation layer will:")
+		fmt.Println("1. Generate alt-text in English first")
+		fmt.Println("2. Then translate to the target language")
+		config.LLM.UseTranslationLayer = promptBool(Cyan+"Enable translation layer (true/false)?"+Reset, "true")
+
+		if config.LLM.Provider == "ollama" {
+			config.LLM.OllamaModel = promptString(Green+"Ollama Model Name:"+Reset, config.LLM.OllamaModel)
+		}
+	} else if config.LLM.Provider == "gemini" {
+		config.Gemini.APIKey = promptString(Green+"Gemini API Key:"+Reset, config.Gemini.APIKey)
+		config.Gemini.Model = promptString(Yellow+"Gemini Model (gemini-1.5-flash/gemini-1.5-pro):"+Reset, config.Gemini.Model)
+	}
 
 	config.RateLimit.Enabled = promptBool(Cyan+"Enable Rate Limiting (true/false)?"+Reset, fmt.Sprintf("%t", config.RateLimit.Enabled))
 	config.WeeklySummary.Enabled = promptBool(Blue+"Enable Weekly Summary (true/false)?"+Reset, fmt.Sprintf("%t", config.WeeklySummary.Enabled))

--- a/translation_layer.go
+++ b/translation_layer.go
@@ -1,0 +1,350 @@
+// translation_layer.go
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// TranslationLayer handles the two-step process of generating alt-text in English
+// and then translating it to the target language
+type TranslationLayer struct {
+	provider LLMProvider
+}
+
+// NewTranslationLayer creates a new translation layer for the given provider
+func NewTranslationLayer(provider LLMProvider) *TranslationLayer {
+	return &TranslationLayer{
+		provider: provider,
+	}
+}
+
+// GenerateAndTranslateAltText first generates alt-text in English, then translates to target language
+func (t *TranslationLayer) GenerateAndTranslateAltText(prompt string, imageData []byte, format string, targetLanguageCode string) (string, error) {
+	englishPrompt := getLocalizedString("en", "generateAltText", "prompt")
+
+	englishAltText, err := t.provider.GenerateAltText(englishPrompt, imageData, format, "en")
+	if err != nil {
+		return "", fmt.Errorf("error generating English alt-text: %v", err)
+	}
+
+	// If target language is English, return the result directly
+	if strings.HasPrefix(strings.ToLower(targetLanguageCode), "en") {
+		return englishAltText, nil
+	}
+
+	targetLanguageName := getLanguageName(targetLanguageCode)
+
+	translationPrompt := fmt.Sprintf(
+		"Translate the following image description to %s, maintaining all details. Your response should only be the translated text:\n\n%s",
+		targetLanguageName,
+		englishAltText,
+	)
+
+	// Call the same LLM but without the image for translation
+	translatedText, err := t.translateText(translationPrompt)
+	if err != nil {
+		return "", fmt.Errorf("error translating alt-text: %v", err)
+	}
+
+	return translatedText, nil
+}
+
+// translateText uses the LLM to translate text without an image
+func (t *TranslationLayer) translateText(prompt string) (string, error) {
+	// Implementation depends on the provider type
+	switch provider := t.provider.(type) {
+	case *OllamaProvider:
+		return t.translateWithOllama(provider, prompt)
+	case *TransformersProvider:
+		return t.translateWithTransformers(provider, prompt)
+	default:
+		return "", fmt.Errorf("unsupported provider type for translation")
+	}
+}
+
+// translateWithOllama translates text using Ollama
+func (t *TranslationLayer) translateWithOllama(provider *OllamaProvider, prompt string) (string, error) {
+	cmd := exec.Command("ollama", "run", provider.model, prompt)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	if err != nil {
+		return "", err
+	}
+	return out.String(), nil
+}
+
+// translateWithTransformers translates text using Transformers
+func (t *TranslationLayer) translateWithTransformers(provider *TransformersProvider, prompt string) (string, error) {
+	// Prepare the request payload for text-only input
+	payload := map[string]interface{}{
+		"model": provider.Model,
+		"messages": []map[string]interface{}{
+			{
+				"role": "user",
+				"content": []map[string]interface{}{
+					{
+						"type": "text",
+						"text": prompt,
+					},
+				},
+			},
+		},
+	}
+
+	jsonData, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("error marshaling JSON: %v", err)
+	}
+
+	fullURL := fmt.Sprintf("%s/v1/chat/completions", provider.ServerURL)
+	client := &http.Client{Timeout: 30 * time.Second}
+
+	resp, err := client.Post(fullURL, "application/json", bytes.NewBuffer(jsonData))
+	if err != nil {
+		return "", fmt.Errorf("error making request to server: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("error reading response body: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("server returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result struct {
+		Choices []struct {
+			Message struct {
+				Content string `json:"content"`
+			} `json:"message"`
+		} `json:"choices"`
+	}
+
+	if err := json.Unmarshal(body, &result); err != nil {
+		return "", fmt.Errorf("error parsing JSON response: %s", string(body))
+	}
+
+	if len(result.Choices) == 0 {
+		return "", fmt.Errorf("no choices in response: %s", string(body))
+	}
+
+	return result.Choices[0].Message.Content, nil
+}
+
+// getLanguageName returns the full language name for a given language code
+func getLanguageName(langCode string) string {
+	switch langCode {
+	case "en":
+		return "English"
+	case "es":
+		return "Spanish"
+	case "fr":
+		return "French"
+	case "de":
+		return "German"
+	case "it":
+		return "Italian"
+	case "pt":
+		return "Portuguese"
+	case "ru":
+		return "Russian"
+	case "zh":
+		return "Chinese"
+	case "ja":
+		return "Japanese"
+	case "ko":
+		return "Korean"
+	case "ar":
+		return "Arabic"
+	case "bg":
+		return "Bulgarian"
+	case "ca":
+		return "Catalan"
+	case "cs":
+		return "Czech"
+	case "da":
+		return "Danish"
+	case "nl":
+		return "Dutch"
+	case "fi":
+		return "Finnish"
+	case "el":
+		return "Greek"
+	case "he":
+		return "Hebrew"
+	case "hi":
+		return "Hindi"
+	case "hu":
+		return "Hungarian"
+	case "id":
+		return "Indonesian"
+	case "lv":
+		return "Latvian"
+	case "lt":
+		return "Lithuanian"
+	case "no":
+		return "Norwegian"
+	case "pl":
+		return "Polish"
+	case "ro":
+		return "Romanian"
+	case "sk":
+		return "Slovak"
+	case "sl":
+		return "Slovenian"
+	case "sv":
+		return "Swedish"
+	case "th":
+		return "Thai"
+	case "tr":
+		return "Turkish"
+	case "uk":
+		return "Ukrainian"
+	case "vi":
+		return "Vietnamese"
+	case "fa":
+		return "Persian"
+	case "ms":
+		return "Malay"
+	case "bn":
+		return "Bengali"
+	case "ta":
+		return "Tamil"
+	case "te":
+		return "Telugu"
+	case "mr":
+		return "Marathi"
+	case "ur":
+		return "Urdu"
+	case "hr":
+		return "Croatian"
+	case "sr":
+		return "Serbian"
+	case "bs":
+		return "Bosnian"
+	case "mk":
+		return "Macedonian"
+	case "sq":
+		return "Albanian"
+	case "et":
+		return "Estonian"
+	case "is":
+		return "Icelandic"
+	case "ga":
+		return "Irish"
+	case "cy":
+		return "Welsh"
+	case "gl":
+		return "Galician"
+	case "eu":
+		return "Basque"
+	case "af":
+		return "Afrikaans"
+	case "sw":
+		return "Swahili"
+	case "zu":
+		return "Zulu"
+	case "xh":
+		return "Xhosa"
+	case "st":
+		return "Sesotho"
+	case "hy":
+		return "Armenian"
+	case "ka":
+		return "Georgian"
+	case "az":
+		return "Azerbaijani"
+	case "be":
+		return "Belarusian"
+	case "kk":
+		return "Kazakh"
+	case "ky":
+		return "Kyrgyz"
+	case "tg":
+		return "Tajik"
+	case "tk":
+		return "Turkmen"
+	case "uz":
+		return "Uzbek"
+	case "mn":
+		return "Mongolian"
+	case "my":
+		return "Burmese"
+	case "km":
+		return "Khmer"
+	case "lo":
+		return "Lao"
+	case "ne":
+		return "Nepali"
+	case "si":
+		return "Sinhala"
+	case "ml":
+		return "Malayalam"
+	case "kn":
+		return "Kannada"
+	case "pa":
+		return "Punjabi"
+	case "gu":
+		return "Gujarati"
+	case "or":
+		return "Odia"
+	case "as":
+		return "Assamese"
+	case "mt":
+		return "Maltese"
+	case "eo":
+		return "Esperanto"
+	case "la":
+		return "Latin"
+	case "gd":
+		return "Scottish Gaelic"
+	case "yi":
+		return "Yiddish"
+	case "fo":
+		return "Faroese"
+	case "haw":
+		return "Hawaiian"
+	case "mi":
+		return "Maori"
+	case "sm":
+		return "Samoan"
+	case "fil":
+		return "Filipino"
+	case "jv":
+		return "Javanese"
+	case "su":
+		return "Sundanese"
+	case "ha":
+		return "Hausa"
+	case "yo":
+		return "Yoruba"
+	case "ig":
+		return "Igbo"
+	case "am":
+		return "Amharic"
+	case "so":
+		return "Somali"
+	case "ps":
+		return "Pashto"
+	case "dv":
+		return "Dhivehi"
+	case "tt":
+		return "Tatar"
+	case "ug":
+		return "Uyghur"
+	case "bo":
+		return "Tibetan"
+	default:
+		return "Unknown"
+	}
+}


### PR DESCRIPTION
we generate alt-text in english and then reprompt it to translate it to the target langague. this is necessary due to the very limited multilingual training sets of images (most LLMs are only trained on english images)