### PR TITLE
Put provided-by text first

### DIFF
--- a/main.go
+++ b/main.go
@@ -923,7 +923,7 @@ func generateAndPostAltText(c *mastodon.Client, status *mastodon.Status, replyTo
 
 	// Add provider attribution
 	if altTextGenerated {
-		combinedResponse = fmt.Sprintf("%s\n\n%s", combinedResponse, getProviderAttribution(config, replyPost.Language))
+		combinedResponse = fmt.Sprintf("%s\n\n%s", getProviderAttribution(config, replyPost.Language), combinedResponse)
 	}
 
 	// Add power consumption information at the end if enabled and using a local model


### PR DESCRIPTION
Addresses #93 

To my understanding (I'm not blind or otherwise reliant on screen readers, take this with a grain of salt), this shouldn't cause much issue for people who do want to hear altbot's image descriptions, as skipping the first line of text is a single keypress. On the other hand, blind users who don't want to listen to an altbot image description can make that decision up-front.